### PR TITLE
Correct unregister_chrdev_region signature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ extern "C" {
     static parrot_release_ptr: *mut extern "C" fn(*mut u8, *mut u8) -> i32;
     fn printk(msg: *const u8);
     fn alloc_chrdev_region(first: *const u32, first_minor: u32, count: u32, name: *const u8) -> i32;
-    fn unregister_chrdev_region(first: u32, count: u32) -> i32;
+    fn unregister_chrdev_region(first: u32, count: u32);
 	#[inline]
     fn copy_to_user_ffi(to: *mut u8, from: *const u8, count: u64) -> u64;
     fn cdev_init(cdev: *mut u8, fops: *const u8);
@@ -109,7 +109,7 @@ impl ParrotSafe {
     }
 
     #[inline]
-    fn unregister_chrdev_region_safe(&mut self) -> i32 {
+    fn unregister_chrdev_region_safe(&mut self) {
         unsafe { unregister_chrdev_region(self.dev, self.count) }
     }
 


### PR DESCRIPTION
The function signature

https://github.com/jbaublitz/knock-out/blob/f22ba56690ad221ff5fe2f9e8eeae2dd33b89688/src/lib.rs#L32

should have no return result, as described [here](https://elixir.bootlin.com/linux/latest/source/fs/char_dev.c#L310).