### PR TITLE
Using staticlib instead of emitting an object file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,7 @@
 name = "knock-out"
 version = "0.1.0"
 authors = ["John Baublitz <john.m.baublitz@gmail.com>"]
+
+[lib]
+name = "parrot"
+crate-type = ["staticlib"]

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
 obj-m += parrot.o
-parrot-objs := src/rust.o src/ffi.o
+parrot-objs := src/ffi.o libparrot.a
+ldflags-y += --undefined=init_module --undefined=cleanup_module
 
-all: src/rust.o
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+all modules:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules V=1
+
+$(obj)/libparrot.a: $(src)/src/lib.rs $(src)/Cargo.toml
+	cd $(src) && cargo rustc --release --lib -- -C relocation-model=static -C code-model=kernel -Z plt=y
+	cp $(src)/target/release/libparrot.a $(obj)
 
 clean:
 	cargo clean
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
 
-src/rust.o: src/lib.rs
-	cargo rustc --release -- --crate-type=staticlib -C relocation-model=static -C code-model=kernel -Z plt=y --emit obj=src/rust.o


### PR DESCRIPTION
The PR compiles the Rust part into a normal `staticlib` then link with the object file generated from compiling the C file `src/ffi.c`.

I've pushed a more detail context in #5 

Thank you in advance.